### PR TITLE
Handle the report path with --diff-only

### DIFF
--- a/src/Conversion/Differ.cs
+++ b/src/Conversion/Differ.cs
@@ -107,7 +107,10 @@ namespace Conversion
                 report.AddRange(diff.GetDiffLines());
             }
 
-            File.WriteAllLines(reportFilePath, report);
+            reportFilePath = string.IsNullOrWhiteSpace(reportFilePath) ? Directory.GetCurrentDirectory() : reportFilePath;
+            var filePath = Path.Combine(reportFilePath, "report.txt");
+
+            File.WriteAllLines(filePath, report);
         }
     }
 }

--- a/src/try-convert/Properties/launchSettings.json
+++ b/src/try-convert/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Diff": {
       "commandName": "Project",
-      "commandLineArgs": "-p \"C:\\Users\\phcart\\source\\repos\\WpfApp15\\WpfApp15\\WpfApp15.csproj\" -o \"C:\\Users\\phcart\\scratch\""
+      "commandLineArgs": "-p \"C:\\Users\\phcart\\source\\repos\\WpfApp16\\WpfApp16\\WpfApp16.csproj\" --diff-only"
     },
     "Convert": {
       "commandName": "Project",


### PR DESCRIPTION
Failed if unspecified; CWD is assumed if nothing is specified.