### PR TITLE
There can be many different types of projects in a solution

### DIFF
--- a/src/MSBuildAbstractions/MSBuildWorkspace.cs
+++ b/src/MSBuildAbstractions/MSBuildWorkspace.cs
@@ -21,6 +21,14 @@ namespace MSBuildAbstractions
 
             foreach (var path in paths)
             {
+                var fileExtension = Path.GetExtension(path);
+                if ((StringComparer.OrdinalIgnoreCase.Compare(fileExtension, ".csproj") != 0) &&
+                    (StringComparer.OrdinalIgnoreCase.Compare(fileExtension, ".vbproj") != 0))
+                {
+                    Console.WriteLine($"'{path}' is not a .NET project, skipping it.");
+                    continue;
+                }
+
                 if (!noBackup)
                 {
                     File.Copy(path, path + ".old");


### PR DESCRIPTION
Tell the user that we only support csproj and vbproj items