### PR TITLE
Show help when no argument is passed

### DIFF
--- a/src/try-convert/Program.cs
+++ b/src/try-convert/Program.cs
@@ -28,7 +28,7 @@ namespace TryConvert
                 .AddOption(new Option(new[] { "--no-backup"}, "Converts projects and does not create a backup of the originals.", new Argument<bool>()))
                 .Build();
 
-            return await parser.InvokeAsync(args).ConfigureAwait(false);
+            return await parser.InvokeAsync(args.Length > 0 ? args : new string[] { "-h" }).ConfigureAwait(false);
         }
 
         public static int Run(string project, string workspace, string msbuildPath, bool diffOnly, bool noBackup)


### PR DESCRIPTION
This is not really a bug fix, but a little improvement. The current try-convert is showing an exception if not argument is passed:

```powershell
PS D:\Development\Personal\try-convert\artifacts\bin\try-convert\Debug\netcoreapp3.0> .\try-convert.exe
System.ArgumentException: No valid arguments to fulfill a workspace are given.
   at TryConvert.Program.Run(String project, String workspace, String msbuildPath, Boolean diffOnly, Boolean noBackup) in D:\Development\Personal\try-convert\src\try-convert\Program.cs:line 71
```

A quick check for arguments length to check if it 0 and it should show the help that is already included:

```csharp
return await parser.InvokeAsync(args.Length > 0 ? args : new string[] { "-h" }).ConfigureAwait(false);
```

```
PS D:\Development\PRs\try-convert\artifacts\bin\try-convert\Debug\netcoreapp3.0> .\try-convert.exe
Usage:
  try-convert [options]

Options:
  -p, --project <P>          The path to a project to convert
  -w, --workspace <W>        The solution or project file to operate on. If a project is not specified, the command will search the current directory for one.
  -m, --msbuild-path <M>     The path to an MSBuild.exe, if you prefer to use that
  --diff-only <DIFF-ONLY>    Produces a diff of the project to convert; no conversion is done
  --no-backup <NO-BACKUP>    Converts projects and does not create a backup of the originals.
```
