### PR TITLE
Remove targets and props if they're from packages

### DIFF
--- a/src/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -265,6 +265,14 @@ namespace MSBuild.Abstractions
             !projectMetadata.Name.Equals(MSBuildFacts.RequiredTargetFrameworkNodeName, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
+        /// Checks if an import is a target that comes from the packages directory (which would mean it's probably brought in via a NuGet package).
+        /// </summary>
+        public static bool IsTargetFromNuGetPackage(ProjectImportElement import) =>
+            import.Project.ContainsIgnoreCase(MSBuildFacts.PackagesSubstring)
+            && (import.Project.EndsWith(MSBuildFacts.TargetsSuffix, StringComparison.OrdinalIgnoreCase)
+                 || import.Project.EndsWith(MSBuildFacts.PropsSuffix, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
         /// Gets the top-level property group, and if it doesn't exist, creates it.
         /// </summary>
         public static ProjectPropertyGroupElement GetOrCreateTopLevelPropertyGroup(BaselineProject baselineProject, IProjectRootElement projectRootElement)

--- a/src/MSBuild.Abstractions/ProjectStyle.cs
+++ b/src/MSBuild.Abstractions/ProjectStyle.cs
@@ -13,12 +13,7 @@
         DefaultSubset,
 
         /// <summary>
-        /// The project imports props and targets but not the default ones. 
-        /// </summary>
-        DefaultWithCustomTargets,
-
-        /// <summary>
-        /// Has more imports and the shape is unknown.
+        /// Not using any default targets or props.
         /// </summary>
         Custom,
 

--- a/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -225,5 +225,8 @@ namespace MSBuild.Conversion.Facts
         public const string LegacyTargetFrameworkProfileNodeName = "TargetFrameworkProfile";
         public const string NETPortableTFValuePrefix = ".NETPortable";
         public const string PCLv5value = "v5.0";
+        public const string TargetsSuffix = ".targets";
+        public const string PropsSuffix = ".props";
+        public const string PackagesSubstring = @"\packages";
     }
 }

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensions.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensions.cs
@@ -288,7 +288,7 @@ namespace MSBuild.Conversion.Project
             return projectRootElement;
         }
 
-        public static IProjectRootElement AddPackage(this IProjectRootElement projectRootElement, string packageName, string packageVersion)
+        private static IProjectRootElement AddPackage(this IProjectRootElement projectRootElement, string packageName, string packageVersion)
         {
             var packageReferencesItemGroup = MSBuildHelpers.GetOrCreatePackageReferencesItemGroup(projectRootElement);
             AddPackageReferenceElement(packageReferencesItemGroup, packageName, packageVersion);


### PR DESCRIPTION
fixes #102

Also gets rid of DefaultWithCustomImports because that seems like a scenario that shouldn't exist in the first place