### PR TITLE
When run with no commands, default to -w in the CWD

### DIFF
--- a/src/try-convert/Program.cs
+++ b/src/try-convert/Program.cs
@@ -38,7 +38,7 @@ namespace MSBuild.Conversion
                 .AddOption(new Option(new[] { "--no-backup" }, "Converts projects and does not create a backup of the originals.") { Argument = new Argument<bool>(() => false) })
                 .Build();
 
-            return await parser.InvokeAsync(args.Length > 0 ? args : new string[] { "-h" }).ConfigureAwait(false);
+            return await parser.InvokeAsync(args).ConfigureAwait(false);
         }
 
         public static int Run(string? project, string? workspace, string? msbuildPath, string? tfm, bool allowPreviews, bool diffOnly, bool noBackup)
@@ -72,7 +72,6 @@ namespace MSBuild.Conversion
                     }
                 }
 
-                var currentDirectory = Environment.CurrentDirectory;
                 var workspacePath = string.Empty;
                 MSBuildWorkspaceType workspaceType;
 
@@ -81,15 +80,11 @@ namespace MSBuild.Conversion
                     workspacePath = Path.GetFullPath(project, Environment.CurrentDirectory);
                     workspaceType = MSBuildWorkspaceType.Project;
                 }
-                else if (!string.IsNullOrWhiteSpace(workspace))
-                {
-                    var (isSolution, workspaceFilePath) = MSBuildWorkspaceFinder.FindWorkspace(currentDirectory, workspace);
-                    workspaceType = isSolution ? MSBuildWorkspaceType.Solution : MSBuildWorkspaceType.Project;
-                    workspacePath = workspaceFilePath;
-                }
                 else
                 {
-                    throw new ArgumentException("No valid arguments to fulfill a workspace are given.");
+                    var (isSolution, workspaceFilePath) = MSBuildWorkspaceFinder.FindWorkspace(Environment.CurrentDirectory, workspace);
+                    workspaceType = isSolution ? MSBuildWorkspaceType.Solution : MSBuildWorkspaceType.Project;
+                    workspacePath = workspaceFilePath;
                 }
 
                 var workspaceLoader = new MSBuildWorkspaceLoader(workspacePath, workspaceType);


### PR DESCRIPTION
Before:

* `try-convert` with nothing else specified printed the help text
* An exception path exists in the code but can only get hit if you somehow manage to pass in a null or empty string and make it through the commandline api handler

After:

* `try-convert` with nothing else runs as if it were `try-convert -w .`
* `try-convert -p` or `try-convert -w` errors out with help text because this is handled by the command line API
* `try-convert -h` prints the help text