### PR TITLE
Add keep-current-tfms option

### DIFF
--- a/src/MSBuild.Abstractions/BaselineProject.cs
+++ b/src/MSBuild.Abstractions/BaselineProject.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Linq;
+using MSBuild.Conversion.Facts;
 
 namespace MSBuild.Abstractions
 {
@@ -15,6 +17,30 @@ namespace MSBuild.Abstractions
             GlobalProperties = globalProperties;
             Project = project ?? throw new ArgumentNullException(nameof(project));
             ProjectStyle = projectStyle;
+        }
+
+        public string GetTfm()
+        {
+            if (GlobalProperties.Contains(MSBuildFacts.TargetFrameworkNodeName, StringComparer.OrdinalIgnoreCase))
+            {
+                // The original project had a TargetFramework property. No need to add it again.
+                return GlobalProperties.First(p => p.Equals(MSBuildFacts.TargetFrameworkNodeName, StringComparison.OrdinalIgnoreCase));
+            }
+            var rawTFM = Project.FirstConfiguredProject.GetProperty(MSBuildFacts.TargetFrameworkNodeName)?.EvaluatedValue;
+            if (rawTFM == null)
+            {
+                throw new InvalidOperationException(
+                    $"{MSBuildFacts.TargetFrameworkNodeName} is not set in {nameof(Project.FirstConfiguredProject)}");
+            }
+
+            // This is pretty much never gonna happen, but it was cheap to write the code
+            return MSBuildHelpers.IsNotNetFramework(rawTFM) ? StripDecimals(rawTFM) : rawTFM;
+
+            static string StripDecimals(string tfm)
+            {
+                var parts = tfm.Split('.');
+                return string.Join("", parts);
+            }
         }
     }
 }

--- a/src/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -142,12 +142,10 @@ namespace MSBuild.Abstractions
         /// </summary>
         public static bool FrameworkHasAValueTuple(string tfm)
         {
-            return tfm.ContainsIgnoreCase(MSBuildFacts.NetstandardPrelude)
-                || tfm.ContainsIgnoreCase(MSBuildFacts.NetcoreappPrelude)
-                ? false
-                : !tfm.StartsWith("net", StringComparison.OrdinalIgnoreCase)
-                    ? false
-                    : tfm.StartsWith(MSBuildFacts.LowestFrameworkVersionWithSystemValueTuple);
+            return !tfm.ContainsIgnoreCase(MSBuildFacts.NetstandardPrelude)
+                && !tfm.ContainsIgnoreCase(MSBuildFacts.NetcoreappPrelude)
+                && (tfm.StartsWith("net", StringComparison.OrdinalIgnoreCase)
+                    && tfm.StartsWith(MSBuildFacts.LowestFrameworkVersionWithSystemValueTuple));
         }
 
         /// <summary>

--- a/src/MSBuild.Conversion.Project/Converter.cs
+++ b/src/MSBuild.Conversion.Project/Converter.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using System.Xml.Linq;
 
 using MSBuild.Abstractions;
+using MSBuild.Conversion.Facts;
 
 namespace MSBuild.Conversion.Project
 {
@@ -23,9 +24,44 @@ namespace MSBuild.Conversion.Project
             _differs = GetDiffers();
         }
 
-        public void Convert(string defaultTFM, string outputPath)
+        public void Convert(string outputPath, string defaultTFM, bool keepCurrentTfm)
         {
-            ConvertProjectFile(defaultTFM);
+            ConvertProjectFile(defaultTFM, keepCurrentTfm);
+            CleanUpProjectFile(outputPath);
+        }
+
+        internal IProjectRootElement ConvertProjectFile(string defaultTFM, bool keepCurrentTfm)
+        {
+            var tfm = _sdkBaselineProject.ProjectStyle switch
+            {
+                ProjectStyle.WindowsDesktop when !keepCurrentTfm => defaultTFM,
+                ProjectStyle.MSTest when !keepCurrentTfm => defaultTFM,
+                _ => _sdkBaselineProject.GetTfm()
+            };
+
+            return _projectRootElement
+                // Let's convert packages first, since that's what you should do manually anyways
+                .ConvertAndAddPackages(_sdkBaselineProject.ProjectStyle, tfm)
+
+                // Now we can convert the project over
+                .ChangeImportsAndAddSdkAttribute(_sdkBaselineProject)
+                .RemoveDefaultedProperties(_sdkBaselineProject, _differs)
+                .RemoveUnnecessaryPropertiesNotInSDKByDefault(_sdkBaselineProject.ProjectStyle)
+                .AddTargetFrameworkProperty(_sdkBaselineProject, tfm)
+                .AddGenerateAssemblyInfoAsFalse()
+                .AddDesktopProperties(_sdkBaselineProject)
+                .AddCommonPropertiesToTopLevelPropertyGroup()
+                .RemoveOrUpdateItems(_differs, _sdkBaselineProject, tfm)
+                .AddItemRemovesForIntroducedItems(_differs)
+                .RemoveUnnecessaryTargetsIfTheyExist()
+                .ModifyProjectElement();
+        }
+
+        internal ImmutableDictionary<string, Differ> GetDiffers() =>
+            _project.ConfiguredProjects.Select(p => (p.Key, new Differ(p.Value, _sdkBaselineProject.Project.ConfiguredProjects[p.Key]))).ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Item2);
+
+        private void CleanUpProjectFile(string outputPath)
+        {
             var projectXml = _projectRootElement.Xml;
 
             // remove all use of xmlns attributes
@@ -63,25 +99,5 @@ namespace MSBuild.Conversion.Project
             using var writer = XmlWriter.Create(outputPath, writerSettings);
             projectXml.Save(writer);
         }
-
-        internal IProjectRootElement ConvertProjectFile(string defaultTFM)
-        {
-            return _projectRootElement
-                .ChangeImports(_sdkBaselineProject)
-                .RemoveDefaultedProperties(_sdkBaselineProject, _differs)
-                .RemoveUnnecessaryPropertiesNotInSDKByDefault(_sdkBaselineProject.ProjectStyle)
-                .AddTargetFrameworkProperty(_sdkBaselineProject, defaultTFM, out var tfm)
-                .AddGenerateAssemblyInfoAsFalse()
-                .AddDesktopProperties(_sdkBaselineProject)
-                .AddCommonPropertiesToTopLevelPropertyGroup()
-                .ConvertAndAddPackages(_sdkBaselineProject.ProjectStyle, tfm)
-                .RemoveOrUpdateItems(_differs, _sdkBaselineProject, tfm)
-                .AddItemRemovesForIntroducedItems(_differs)
-                .RemoveUnnecessaryTargetsIfTheyExist()
-                .ModifyProjectElement();
-        }
-
-        internal ImmutableDictionary<string, Differ> GetDiffers() =>
-            _project.ConfiguredProjects.Select(p => (p.Key, new Differ(p.Value, _sdkBaselineProject.Project.ConfiguredProjects[p.Key]))).ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Item2);
     }
 }

--- a/src/MSBuild.Conversion.Project/Converter.cs
+++ b/src/MSBuild.Conversion.Project/Converter.cs
@@ -24,18 +24,18 @@ namespace MSBuild.Conversion.Project
             _differs = GetDiffers();
         }
 
-        public void Convert(string outputPath, string defaultTFM, bool keepCurrentTfm)
+        public void Convert(string outputPath, string? defaultTFM, bool keepCurrentTfm)
         {
             ConvertProjectFile(defaultTFM, keepCurrentTfm);
             CleanUpProjectFile(outputPath);
         }
 
-        internal IProjectRootElement ConvertProjectFile(string defaultTFM, bool keepCurrentTfm)
+        internal IProjectRootElement ConvertProjectFile(string? defaultTFM, bool keepCurrentTfm)
         {
             var tfm = _sdkBaselineProject.ProjectStyle switch
             {
-                ProjectStyle.WindowsDesktop when !keepCurrentTfm => defaultTFM,
-                ProjectStyle.MSTest when !keepCurrentTfm => defaultTFM,
+                ProjectStyle.WindowsDesktop when !(keepCurrentTfm || string.IsNullOrWhiteSpace(defaultTFM)) => defaultTFM,
+                ProjectStyle.MSTest when !(keepCurrentTfm || string.IsNullOrWhiteSpace(defaultTFM)) => defaultTFM,
                 _ => _sdkBaselineProject.GetTfm()
             };
 

--- a/src/try-convert/Program.cs
+++ b/src/try-convert/Program.cs
@@ -32,11 +32,11 @@ namespace MSBuild.Conversion
                 .AddOption(new Option(new[] { "-p", "--project" }, "The path to a project to convert") { Argument = new Argument<string?>(() => null) })
                 .AddOption(new Option(new[] { "-w", "--workspace" }, "The solution or project file to operate on. If a project is not specified, the command will search the current directory for one.") { Argument = new Argument<string?>(() => null) })
                 .AddOption(new Option(new[] { "-m", "--msbuild-path" }, "The path to an MSBuild.exe, if you prefer to use that") { Argument = new Argument<string?>(() => null) })
-                .AddOption(new Option(new[] { "-tfm", "--target-framework" }, "The name of the framework you would like to upgrade to. Useful if you'd prefer not to change TFMs to .NET Core just yet.") { Argument = new Argument<string?>(() => null) })
+                .AddOption(new Option(new[] { "-tfm", "--target-framework" }, "The name of the framework you would like to upgrade to. If unspecified, the default TFM chosen will be the highest available one found on your machine.") { Argument = new Argument<string?>(() => null) })
                 .AddOption(new Option(new[] { "--preview" }, "Use preview SDKs as part of conversion") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--diff-only" }, "Produces a diff of the project to convert; no conversion is done") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--no-backup" }, "Converts projects and does not create a backup of the originals.") { Argument = new Argument<bool>(() => false) })
-                .AddOption(new Option(new[] { "--keep-current-tfms" }, "Converts projects but does not change the TFM to .NET Core. Useful if you just move to the .NET SDK, but not .NET Core yet.") { Argument = new Argument<bool>(() => false) })
+                .AddOption(new Option(new[] { "--keep-current-tfms" }, "Converts project files but does not change any TFMs. If unspecified, TFMs may change.") { Argument = new Argument<bool>(() => false) })
                 .Build();
 
             return await parser.InvokeAsync(args).ConfigureAwait(false);
@@ -47,6 +47,12 @@ namespace MSBuild.Conversion
             if (!string.IsNullOrWhiteSpace(project) && !string.IsNullOrWhiteSpace(workspace))
             {
                 Console.WriteLine("Cannot specify both a project and a workspace.");
+                return -1;
+            }
+
+            if (!string.IsNullOrWhiteSpace(tfm) && keepCurrentTfms)
+            {
+                Console.WriteLine($"Both '{nameof(tfm)}' and '{nameof(keepCurrentTfms)}' cannot be specified. Please pick one.");
                 return -1;
             }
 

--- a/tests/end-to-end/Smoke.Tests/BasicConversions.cs
+++ b/tests/end-to-end/Smoke.Tests/BasicConversions.cs
@@ -67,7 +67,7 @@ namespace SmokeTests
 
             var item = conversionWorkspace.WorkspaceItems.Single();
             var converter = new Converter(item.UnconfiguredProject, item.SdkBaselineProject, item.ProjectRootElement);
-            var convertedRootElement = converter.ConvertProjectFile("netcoreapp3.1");
+            var convertedRootElement = converter.ConvertProjectFile("netcoreapp3.1", false);
 
             return (baselineRootElement, convertedRootElement);
         }

--- a/tests/end-to-end/Smoke.Tests/BasicConversions.cs
+++ b/tests/end-to-end/Smoke.Tests/BasicConversions.cs
@@ -67,7 +67,7 @@ namespace SmokeTests
 
             var item = conversionWorkspace.WorkspaceItems.Single();
             var converter = new Converter(item.UnconfiguredProject, item.SdkBaselineProject, item.ProjectRootElement);
-            var convertedRootElement = converter.ConvertProjectFile("netcoreapp3.1", false);
+            var convertedRootElement = converter.ConvertProjectFile("netcoreapp3.1", keepCurrentTfm: false);
 
             return (baselineRootElement, convertedRootElement);
         }


### PR DESCRIPTION
This effectively lets you say, "I am just converting to the .NET SDK for now". Some notes:

* This will still add the desktop SDK and UseWinForms/UseWPF if you have the references
* I tested this out manually and there doesn't appear to be anything inherently wrong with referencing the desktop SDK while targeting .NET Framework, but you may not get the same APIs
* I tested this out on a large internal project and it seems okay

This required some small refactoring around determining the project TFM. This also moves converting to PackageReference to be first, since that's what you'd normally due if you were migrating manually. If we ever wanted to introduce a "just convert my packages" option then this would enable that