### PR TITLE
Fix validation error preventing use of .NET 5 OS-specific TFMs

### DIFF
--- a/src/MSBuild.Conversion.SDK/TargetFrameworkHelper.cs
+++ b/src/MSBuild.Conversion.SDK/TargetFrameworkHelper.cs
@@ -89,6 +89,6 @@ namespace MSBuild.Conversion.SDK
         /// Reject obviously wrong TFM specifiers 
         /// </summary>
         public static bool IsValidTargetFramework(string tfm)
-            => !tfm.Contains("-") && !tfm.Contains(" ") && tfm.Contains("net") && Regex.Match(tfm, "[0-9]").Success;
+            => !tfm.Contains(" ") && tfm.Contains("net") && Regex.Match(tfm, "[0-9]").Success;
     }
 }


### PR DESCRIPTION
The "_Reject obviously wrong TFM specifiers_" was "_obviously wrong_" for .NET 5 :laughing:

Resolves #321 