### PR TITLE
Fixed usage of TryParse

### DIFF
--- a/src/MSBuild.Conversion.Package/PackagesConfigParser.cs
+++ b/src/MSBuild.Conversion.Package/PackagesConfigParser.cs
@@ -79,7 +79,7 @@ namespace MSBuild.Conversion.Package
 
                     AllowedVersions = element.Attribute(PackageFacts.PackagesConfigAllowedVersionsFrameworkname)?.Value,
 
-                    DevelopmentDependency = bool.TryParse(element.Attribute(PackageFacts.PackagesConfigDevelopmentDependencyName)?.Value, out var _),
+                    DevelopmentDependency = bool.TryParse(element.Attribute(PackageFacts.PackagesConfigDevelopmentDependencyName)?.Value, out var value) ? value : false,
                 };
 
             static string VersionWithoutSuffix(string nugetVersion) => nugetVersion.Split('-').First();


### PR DESCRIPTION
Fixed the usage of TryParse to get the correct value for DevelopmentDependency in the PackagesConfigParser.  TryParse returns true only if the Parse is successful.  You need to get the actual parsed value if successful.