### PR TITLE
Enable conversion of web projects

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>5</MinorVersion>
+    <MinorVersion>6</MinorVersion>
     <!-- Build release-only package. -->
     <PreReleaseVersionLabel />
   </PropertyGroup>

--- a/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
+++ b/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
@@ -240,7 +240,7 @@ namespace MSBuild.Abstractions
                     }
 
                     if (MSBuildFacts.PropsConvertibleToSDK.Contains(firstImportFileName, StringComparer.OrdinalIgnoreCase) &&
-                        MSBuildFacts.TargetsConvertibleToSDK.Contains(lastImportFileName, StringComparer.OrdinalIgnoreCase))
+                        imports.Any(import => MSBuildFacts.TargetsConvertibleToSDK.Contains(Path.GetFileName(import.Project), StringComparer.OrdinalIgnoreCase)))
                     {
                         if (MSBuildHelpers.IsNETFrameworkMSTestProject(projectRootElement))
                         {

--- a/src/MSBuild.Abstractions/MSBuildConversionWorkspaceLoader.cs
+++ b/src/MSBuild.Abstractions/MSBuildConversionWorkspaceLoader.cs
@@ -29,7 +29,7 @@ namespace MSBuild.Abstractions
             _workspaceType = workspaceType;
         }
 
-        public MSBuildConversionWorkspace LoadWorkspace(string path, bool noBackup)
+        public MSBuildConversionWorkspace LoadWorkspace(string path, bool noBackup, bool forceWeb)
         {
             var projectPaths =
                 _workspaceType switch
@@ -42,7 +42,7 @@ namespace MSBuild.Abstractions
                     _ => throw new InvalidOperationException("Somehow, an enum that isn't possible was passed in here.")
                 };
 
-            return new MSBuildConversionWorkspace(projectPaths, noBackup);
+            return new MSBuildConversionWorkspace(projectPaths, noBackup, forceWeb);
 
             static bool IsSupportedSolutionItemType(ProjectInSolution project)
             {

--- a/src/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -173,7 +173,7 @@ namespace MSBuild.Abstractions
         public static bool IsWPF(IProjectRootElement projectRoot)
         {
             var references = projectRoot.ItemGroups.SelectMany(GetReferences)?.Select(elem => elem.Include.Split(',').First());
-            return DesktopFacts.KnownWPFReferences.Any(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
+            return DesktopFacts.KnownWPFReferences.All(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace MSBuild.Abstractions
         public static bool IsWinForms(IProjectRootElement projectRoot)
         {
             var references = projectRoot.ItemGroups.SelectMany(GetReferences)?.Select(elem => elem.Include.Split(',').First());
-            return DesktopFacts.KnownWinFormsReferences.Any(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
+            return DesktopFacts.KnownWinFormsReferences.All(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -191,7 +191,16 @@ namespace MSBuild.Abstractions
         public static bool IsDesktop(IProjectRootElement projectRoot)
         {
             var references = projectRoot.ItemGroups.SelectMany(GetReferences)?.Select(elem => elem.Include.Split(',').First());
-            return DesktopFacts.KnownDesktopReferences.Any(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
+            return DesktopFacts.KnownDesktopReferences.All(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Determines if a given project references ASP.NET assemblies.
+        /// </summary>
+        public static bool IsWeb(IProjectRootElement projectRoot)
+        {
+            var references = projectRoot.ItemGroups.SelectMany(GetReferences)?.Select(elem => elem.Include.Split(',').First());
+            return WebFacts.KnownWebReferences.All(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/src/MSBuild.Abstractions/MSBuildProjectRootElement.cs
+++ b/src/MSBuild.Abstractions/MSBuildProjectRootElement.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 
 using Microsoft.Build.Construction;
@@ -19,6 +21,7 @@ namespace MSBuild.Abstractions
         ICollection<ProjectPropertyGroupElement> PropertyGroups { get; }
         ICollection<ProjectItemGroupElement> ItemGroups { get; }
         ICollection<ProjectTargetElement> Targets { get; }
+        ProjectExtensionsElement? ProjectExtensions { get; }
 
         ProjectPropertyElement CreatePropertyElement(string propertyName);
         ProjectPropertyGroupElement AddPropertyGroup();
@@ -31,6 +34,8 @@ namespace MSBuild.Abstractions
 
     public class MSBuildProjectRootElement : IProjectRootElement
     {
+        private const string ProjectExtensionsElementName = "ProjectExtensions";
+
         private readonly ProjectRootElement _rootElement;
 
         public MSBuildProjectRootElement(ProjectRootElement rootElement)
@@ -50,6 +55,7 @@ namespace MSBuild.Abstractions
         public ICollection<ProjectPropertyGroupElement> PropertyGroups => _rootElement.PropertyGroups;
         public ICollection<ProjectItemGroupElement> ItemGroups => _rootElement.ItemGroups;
         public ICollection<ProjectTargetElement> Targets => _rootElement.Targets;
+        public ProjectExtensionsElement? ProjectExtensions => _rootElement.Children.FirstOrDefault(e => e.ElementName.Equals(ProjectExtensionsElementName, StringComparison.OrdinalIgnoreCase)) as ProjectExtensionsElement;
 
         public ProjectItemGroupElement AddItemGroup() => _rootElement.AddItemGroup();
 

--- a/src/MSBuild.Abstractions/ProjectStyle.cs
+++ b/src/MSBuild.Abstractions/ProjectStyle.cs
@@ -25,6 +25,13 @@
         /// <summary>
         /// The project is an MSTest project that pulls in a lot of unnecessary imports.
         /// </summary>
-        MSTest
+        MSTest,
+
+        /// <summary>
+        /// The project is an ASP.NET project that will not be possible to completely convert automatically.
+        /// If the user has specified --force-web-conversion, a best-effort will be made using the
+        /// Microsoft.NET.Sdk.Web SDK.
+        /// </summary>
+        Web
     }
 }

--- a/src/MSBuild.Conversion.Facts/DesktopFacts.cs
+++ b/src/MSBuild.Conversion.Facts/DesktopFacts.cs
@@ -39,8 +39,7 @@ namespace MSBuild.Conversion.Facts
         /// </remarks>
         public static ImmutableArray<string> KnownWinFormsReferences => ImmutableArray.Create(
             "System.Windows.Forms",
-            "System.Deployment",
-            "System.Drawing"
+            "System.Deployment"
         );
 
         public static ImmutableArray<string> KnownDesktopReferences => ImmutableArray.Create(

--- a/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -26,7 +26,8 @@ namespace MSBuild.Conversion.Facts
             "Microsoft.Portable.CSharp.targets",
             "Microsoft.Portable.VisualBasic.targets",
             "Microsoft.FSharp.Targets",
-            "MSTest.TestAdapter.targets"
+            "MSTest.TestAdapter.targets",
+            "Microsoft.WebApplication.targets"
         );
 
         /// <summary>
@@ -57,6 +58,7 @@ namespace MSBuild.Conversion.Facts
 
         public static ImmutableArray<string> UnnecessaryProperties => ImmutableArray.Create(
             // The following are unecessary in CPS and/or are already in the .NET SDK
+            "OldToolsVersion",
             "ProjectGuid",
             "ProjectTypeGuids",
             "TargetFrameworkIdentifier",
@@ -77,7 +79,22 @@ namespace MSBuild.Conversion.Facts
             "VSToolsPath",
 
             // This is dropped in by templates, but is unlikely to be valid given that the .NET SDK specifies a minimum VS version that will work
-            "VisualStudioVersion"
+            "VisualStudioVersion",
+
+            // ASP.NET Core always defaults to building views
+            "MvcBuildViews",
+
+            // ASP.NET Core does not configure IIS settings in the project file
+            "UseIISExpress",
+            "Use64BitIISExpress",
+            "IISExpressSSLPort",
+            "IISExpressAnonymousAuthentication",
+            "IISExpressWindowsAuthentication",
+            "IISExpressUseClassicPipelineMode",
+
+            // No longer used in ASP.NET Core
+            "MvcProjectUpgradeChecked",
+            "UseGlobalApplicationHostFile"
         );
 
         public static ImmutableArray<string> DefaultDefineConstants => ImmutableArray.Create(
@@ -113,8 +130,50 @@ namespace MSBuild.Conversion.Facts
             // packages.config is now deprecated, user needs to move to PackageReference
             "packages.config",
 
+            // Enterprise Services is no longer supported
+            "System.EnterpriseServices",
+
             // System.Net.Http is a part of the .NET SDK now
-            "System.Net.Http"
+            "System.Net.Http",
+
+            // ASP.NET references are no longer used
+            "System.Web",
+            "System.Web.Abstractions",
+            "System.Web.ApplicationServices",
+            "System.Web.DataVisualization",
+            "System.Web.DynamicData",
+            "System.Web.Entity",
+            "System.Web.Extensions",
+            "System.Web.Extensions.Design",
+            "System.Web.Helpers",
+            "System.Web.Mobile",
+            "System.Web.Mvc",
+            "System.Web.Optimization",
+            "System.Web.Razor",
+            "System.Web.Routing",
+            "System.Web.Services",
+            "System.Web.WebPages",
+            "System.Web.WebPages.Deployment",
+            "System.Web.WebPages.Razor",
+            "System.Net.Http.WebRequest",
+            "Microsoft.AspNet.Mvc",
+            "Microsoft.AspNet.Razor",
+            "Microsoft.AspNet.Identity.Core",
+            "Microsoft.AspNet.Identity.EntityFramework",
+            "Microsoft.AspNet.Identity.Owin",
+            "Microsoft.AspNet.Web.Optimization",
+            "Microsoft.AspNet.WebApi.Core",
+            "Microsoft.AspNet.WebApi.WebHost",
+            "Microsoft.AspNet.WebPages",
+            "Microsoft.CodeDom.Providers.DotNetCompilerPlatform",
+            "Microsoft.Owin",
+            "Microsoft.Owin.Host.SystemWeb",
+            "Microsoft.Owin.Security",
+            "Microsoft.Owin.Security.Cookies",
+            "Microsoft.Owin.Security.OAuth",
+            "Microsoft.Owin.Security.OpenIdConnect",
+            "Microsoft.Web.Infrastructure",
+            "Owin"
         );
 
         public static ImmutableDictionary<string, string> DefaultItemsThatHavePackageEquivalents => ImmutableDictionary.CreateRange(new Dictionary<string, string>

--- a/src/MSBuild.Conversion.Facts/WebFacts.cs
+++ b/src/MSBuild.Conversion.Facts/WebFacts.cs
@@ -7,6 +7,7 @@ namespace MSBuild.Conversion.Facts
         public const string WebSDKAttribute = "Microsoft.NET.Sdk.Web";
         public const string MvcBuildViewsName = "MvcBuildViews";
         public const string WebProjectPropertiesName = "WebProjectProperties";
+        public const string WebApplicationTargets = "Microsoft.WebApplication.targets";
 
         /// <summary>
         /// The core set of references all ASP.NET projects use.

--- a/src/MSBuild.Conversion.Facts/WebFacts.cs
+++ b/src/MSBuild.Conversion.Facts/WebFacts.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Immutable;
+
+namespace MSBuild.Conversion.Facts
+{
+    public static class WebFacts
+    {
+        public const string WebSDKAttribute = "Microsoft.NET.Sdk.Web";
+        public const string MvcBuildViewsName = "MvcBuildViews";
+        public const string WebProjectPropertiesName = "WebProjectProperties";
+
+        /// <summary>
+        /// The core set of references all ASP.NET projects use.
+        /// </summary>
+        public static ImmutableArray<string> KnownWebReferences => ImmutableArray.Create(
+            "System.Web"
+        );
+    }
+}

--- a/src/MSBuild.Conversion.Project/Converter.cs
+++ b/src/MSBuild.Conversion.Project/Converter.cs
@@ -50,6 +50,7 @@ namespace MSBuild.Conversion.Project
                 .RemoveOrUpdateItems(_differs, _sdkBaselineProject, tfm)
                 .AddItemRemovesForIntroducedItems(_differs)
                 .RemoveUnnecessaryTargetsIfTheyExist()
+                .RemoveWebExtensions(_sdkBaselineProject.ProjectStyle)
                 .ModifyProjectElement();
 
             static string GetBestTFM(BaselineProject baselineProject, bool keepCurrentTfm, string? specifiedTFM, bool usePreviewSDK)
@@ -63,7 +64,7 @@ namespace MSBuild.Conversion.Project
                     {
                         specifiedTFM = baselineProject.GetTfm();
                     }
-                    else if (baselineProject.ProjectStyle == ProjectStyle.WindowsDesktop || baselineProject.ProjectStyle == ProjectStyle.MSTest)
+                    else if (baselineProject.ProjectStyle == ProjectStyle.WindowsDesktop || baselineProject.ProjectStyle == ProjectStyle.MSTest || baselineProject.ProjectStyle == ProjectStyle.Web)
                     {
                         specifiedTFM = tfmForApps;
                     }

--- a/src/MSBuild.Conversion.Project/Converter.cs
+++ b/src/MSBuild.Conversion.Project/Converter.cs
@@ -41,6 +41,7 @@ namespace MSBuild.Conversion.Project
 
                 // Now we can convert the project over
                 .ChangeImportsAndAddSdkAttribute(_sdkBaselineProject)
+                .UpdateOutputTypeProperty(_sdkBaselineProject)
                 .RemoveDefaultedProperties(_sdkBaselineProject, _differs)
                 .RemoveUnnecessaryPropertiesNotInSDKByDefault(_sdkBaselineProject.ProjectStyle)
                 .AddTargetFrameworkProperty(_sdkBaselineProject, tfm)

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -39,6 +39,22 @@ namespace MSBuild.Conversion.Project
             return projectRootElement;
         }
 
+        public static IProjectRootElement UpdateOutputTypeProperty(this IProjectRootElement projectRootElement, BaselineProject baselineProject)
+        {
+            var outputTypeNode = projectRootElement.GetOutputTypeNode();
+            if (outputTypeNode != null)
+            {
+                outputTypeNode.Value = baselineProject.OutputType switch
+                {
+                    ProjectOutputType.Exe => MSBuildFacts.ExeOutputType,
+                    ProjectOutputType.Library => MSBuildFacts.LibraryOutputType,
+                    ProjectOutputType.WinExe => MSBuildFacts.WinExeOutputType,
+                    _ => throw new InvalidOperationException("Unsupported output type: " + baselineProject.OutputType)
+                };
+            }
+            return projectRootElement;
+        }
+
         public static IProjectRootElement RemoveDefaultedProperties(this IProjectRootElement projectRootElement, BaselineProject baselineProject, ImmutableDictionary<string, Differ> differs)
         {
             foreach (var propGroup in projectRootElement.PropertyGroups)

--- a/src/try-convert/Program.cs
+++ b/src/try-convert/Program.cs
@@ -42,8 +42,6 @@ namespace MSBuild.Conversion
                 .AddOption(new Option(new[] { "--keep-current-tfms" }, "Converts project files but does not change any TFMs. If unspecified, TFMs may change.") { Argument = new Argument<bool>(() => false) })
                 .Build();
 
-            var result = parser.Parse(args);
-
             return await parser.InvokeAsync(args).ConfigureAwait(false);
         }
 

--- a/src/try-convert/Program.cs
+++ b/src/try-convert/Program.cs
@@ -35,16 +35,19 @@ namespace MSBuild.Conversion
                 .AddOption(new Option(new[] { "-w", "--workspace" }, "The solution or project file to operate on. If a project is not specified, the command will search the current directory for one.") { Argument = new Argument<string?>(() => null) })
                 .AddOption(new Option(new[] { "-m", "--msbuild-path" }, "The path to an MSBuild.exe, if you prefer to use that") { Argument = new Argument<string?>(() => null) })
                 .AddOption(new Option(new[] { "-tfm", "--target-framework" }, "The name of the framework you would like to upgrade to. If unspecified, the default TFM for apps chosen will be the highest available one found on your machine, and the default TFM for libraries will be .NET Standard 2.0.") { Argument = new Argument<string?>(() => null) })
+                .AddOption(new Option(new[] { "--force-web-conversion" }, "Attempt to convert MVC and WebAPI projects even though significant manual work is necessary after migrating such projects.") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--preview" }, "Use preview SDKs as part of conversion") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--diff-only" }, "Produces a diff of the project to convert; no conversion is done") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--no-backup" }, "Converts projects and does not create a backup of the originals.") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--keep-current-tfms" }, "Converts project files but does not change any TFMs. If unspecified, TFMs may change.") { Argument = new Argument<bool>(() => false) })
                 .Build();
 
+            var result = parser.Parse(args);
+
             return await parser.InvokeAsync(args).ConfigureAwait(false);
         }
 
-        public static int Run(string? project, string? workspace, string? msbuildPath, string? tfm, bool allowPreviews, bool diffOnly, bool noBackup, bool keepCurrentTfms)
+        public static int Run(string? project, string? workspace, string? msbuildPath, string? tfm, bool forceWebConversion, bool allowPreviews, bool diffOnly, bool noBackup, bool keepCurrentTfms)
         {
             if (!string.IsNullOrWhiteSpace(project) && !string.IsNullOrWhiteSpace(workspace))
             {
@@ -95,7 +98,7 @@ namespace MSBuild.Conversion
                 var workspaceLoader = new MSBuildConversionWorkspaceLoader(workspacePath, workspaceType);
                 // do not create backup if --diff-only specified
                 noBackup = noBackup || diffOnly;
-                var msbuildWorkspace = workspaceLoader.LoadWorkspace(workspacePath, noBackup);
+                var msbuildWorkspace = workspaceLoader.LoadWorkspace(workspacePath, noBackup, forceWebConversion);
 
                 foreach (var item in msbuildWorkspace.WorkspaceItems)
                 {

--- a/tests/end-to-end/Smoke.Tests/BasicConversions.cs
+++ b/tests/end-to-end/Smoke.Tests/BasicConversions.cs
@@ -60,7 +60,7 @@ namespace SmokeTests
         private static (IProjectRootElement baselineRootElement, IProjectRootElement convertedRootElement) GetRootElementsForComparison(string projectToConvertPath, string projectBaselinePath)
         {
             var conversionLoader = new MSBuildConversionWorkspaceLoader(projectToConvertPath, MSBuildConversionWorkspaceType.Project);
-            var conversionWorkspace = conversionLoader.LoadWorkspace(projectToConvertPath, noBackup: true);
+            var conversionWorkspace = conversionLoader.LoadWorkspace(projectToConvertPath, noBackup: true, forceWeb: false);
 
             var baselineLoader = new MSBuildConversionWorkspaceLoader(projectBaselinePath, MSBuildConversionWorkspaceType.Project);
             var baselineRootElement = baselineLoader.GetRootElementFromProjectFile(projectBaselinePath);


### PR DESCRIPTION
Although we aren't able to completely migrate web projects to Core automatically, it can sometimes be useful to just get the project files updated to SDK-style in preparation for manual conversion later.

To support that, these changes enable converting web projects if the new `--force-web-conversion` parameter is used.

The changes are basically:

1.	Piping through the new command line parameter for opting into web project conversion.
2.	Making ProjectStyle.Web a project style that will be used if the project references System.Web.
3.	Using the Web SDK for projects with the web project style.
4.	Adding some additional ‘UnnecessaryProperties’ and ‘UnnecessaryItemIncludes’ to clean out web project elements that aren’t used in Core.
5.	Removing web extension elements.
