### PR TITLE
Remove packages.config after migration

### DIFF
--- a/src/MSBuild.Conversion.Project/Converter.cs
+++ b/src/MSBuild.Conversion.Project/Converter.cs
@@ -36,7 +36,7 @@ namespace MSBuild.Conversion.Project
         {
             return _projectRootElement
                 // Let's convert packages first, since that's what you should do manually anyways
-                .ConvertAndAddPackages(_sdkBaselineProject.ProjectStyle, _sdkBaselineProject.TargetTFM, _noBackup)
+                .ConvertAndAddPackages(_sdkBaselineProject.ProjectStyle, _sdkBaselineProject.TargetTFM, removePackagesConfig: _noBackup)
 
                 // Now we can convert the project over
                 .ChangeImportsAndAddSdkAttribute(_sdkBaselineProject)

--- a/src/MSBuild.Conversion.Project/Converter.cs
+++ b/src/MSBuild.Conversion.Project/Converter.cs
@@ -13,13 +13,16 @@ namespace MSBuild.Conversion.Project
         private readonly UnconfiguredProject _project;
         private readonly BaselineProject _sdkBaselineProject;
         private readonly IProjectRootElement _projectRootElement;
+        private readonly bool _noBackup;
         private readonly ImmutableDictionary<string, Differ> _differs;
 
-        public Converter(UnconfiguredProject project, BaselineProject sdkBaselineProject, IProjectRootElement projectRootElement)
+        public Converter(UnconfiguredProject project, BaselineProject sdkBaselineProject,
+            IProjectRootElement projectRootElement, bool noBackup)
         {
             _project = project ?? throw new ArgumentNullException(nameof(project));
             _sdkBaselineProject = sdkBaselineProject;
             _projectRootElement = projectRootElement ?? throw new ArgumentNullException(nameof(projectRootElement));
+            _noBackup = noBackup;
             _differs = GetDiffers();
         }
 
@@ -33,7 +36,7 @@ namespace MSBuild.Conversion.Project
         {
             return _projectRootElement
                 // Let's convert packages first, since that's what you should do manually anyways
-                .ConvertAndAddPackages(_sdkBaselineProject.ProjectStyle, _sdkBaselineProject.TargetTFM)
+                .ConvertAndAddPackages(_sdkBaselineProject.ProjectStyle, _sdkBaselineProject.TargetTFM, _noBackup)
 
                 // Now we can convert the project over
                 .ChangeImportsAndAddSdkAttribute(_sdkBaselineProject)

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -317,7 +317,8 @@ namespace MSBuild.Conversion.Project
             return projectRootElement;
         }
 
-        public static IProjectRootElement ConvertAndAddPackages(this IProjectRootElement projectRootElement, ProjectStyle projectStyle, string tfm)
+        public static IProjectRootElement ConvertAndAddPackages(this IProjectRootElement projectRootElement,
+            ProjectStyle projectStyle, string tfm, bool noBackup)
         {
             var packagesConfigItemGroup = MSBuildHelpers.GetPackagesConfigItemGroup(projectRootElement);
             if (packagesConfigItemGroup is null)
@@ -372,6 +373,11 @@ namespace MSBuild.Conversion.Project
             }
 
             packagesConfigItemGroup.RemoveChild(packagesConfigItem);
+            if (noBackup)
+            {
+                File.Delete(path);
+            }
+
             return projectRootElement;
         }
 

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -318,7 +318,7 @@ namespace MSBuild.Conversion.Project
         }
 
         public static IProjectRootElement ConvertAndAddPackages(this IProjectRootElement projectRootElement,
-            ProjectStyle projectStyle, string tfm, bool noBackup)
+            ProjectStyle projectStyle, string tfm, bool removePackagesConfig)
         {
             var packagesConfigItemGroup = MSBuildHelpers.GetPackagesConfigItemGroup(projectRootElement);
             if (packagesConfigItemGroup is null)
@@ -373,7 +373,7 @@ namespace MSBuild.Conversion.Project
             }
 
             packagesConfigItemGroup.RemoveChild(packagesConfigItem);
-            if (noBackup)
+            if (removePackagesConfig)
             {
                 File.Delete(path);
             }

--- a/src/try-convert/Program.cs
+++ b/src/try-convert/Program.cs
@@ -38,7 +38,7 @@ namespace MSBuild.Conversion
                 .AddOption(new Option(new[] { "--force-web-conversion" }, "Attempt to convert MVC and WebAPI projects even though significant manual work is necessary after migrating such projects.") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--preview" }, "Use preview SDKs as part of conversion") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--diff-only" }, "Produces a diff of the project to convert; no conversion is done") { Argument = new Argument<bool>(() => false) })
-                .AddOption(new Option(new[] { "--no-backup" }, "Converts projects and does not create a backup of the originals.") { Argument = new Argument<bool>(() => false) })
+                .AddOption(new Option(new[] { "--no-backup" }, "Converts projects, does not create a backup of the originals and removes packages.config file.") { Argument = new Argument<bool>(() => false) })
                 .AddOption(new Option(new[] { "--keep-current-tfms" }, "Converts project files but does not change any TFMs. If unspecified, TFMs may change.") { Argument = new Argument<bool>(() => false) })
                 .Build();
 
@@ -125,7 +125,7 @@ namespace MSBuild.Conversion
                     }
                     else
                     {
-                        var converter = new Converter(item.UnconfiguredProject, item.SdkBaselineProject, item.ProjectRootElement);
+                        var converter = new Converter(item.UnconfiguredProject, item.SdkBaselineProject, item.ProjectRootElement, noBackup);
                         converter.Convert(item.ProjectRootElement.FullPath);
                     }
                 }

--- a/tests/end-to-end/Smoke.Tests/BasicConversions.cs
+++ b/tests/end-to-end/Smoke.Tests/BasicConversions.cs
@@ -98,7 +98,7 @@ namespace SmokeTests
             var baselineRootElement = baselineLoader.GetRootElementFromProjectFile(projectBaselinePath);
 
             var item = conversionWorkspace.WorkspaceItems.Single();
-            var converter = new Converter(item.UnconfiguredProject, item.SdkBaselineProject, item.ProjectRootElement);
+            var converter = new Converter(item.UnconfiguredProject, item.SdkBaselineProject, item.ProjectRootElement, noBackup: false);
             var convertedRootElement = converter.ConvertProjectFile();
 
             return (baselineRootElement, convertedRootElement);


### PR DESCRIPTION
When migrating project with the option `--no-backup` the file `packages.config` is not removed even merged into new csproj file.

With this PR the file will be deleted after migration if `noBackup` is active.

I know there is no unit test for the new feature. Therefore an abstraction of `File` should be used which I've not identified in your project. How to proceed?
