### PR TITLE
Add ImportWindowsDesktopTargets=true for desktop .NET Framework apps

### DIFF
--- a/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
+++ b/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
@@ -100,7 +100,7 @@ namespace MSBuild.Abstractions
         private void RemoveTargetsNotLoadableByNETSDKMSBuild(string path)
         {
             var projectFile = File.ReadAllText(path);
-            if (projectFile is { Length:>0 })
+            if (projectFile is { Length: > 0 })
             {
                 var replacement =
                     projectFile
@@ -177,6 +177,11 @@ namespace MSBuild.Abstractions
                 if (MSBuildHelpers.IsDesktop(root) && !MSBuildHelpers.HasWPFOrWinForms(propGroup))
                 {
                     MSBuildHelpers.AddUseWinForms(propGroup);
+                }
+
+                if (MSBuildHelpers.HasWPFOrWinForms(propGroup) && tfm.ContainsIgnoreCase(MSBuildFacts.Net5))
+                {
+                    MSBuildHelpers.AddImportWindowsDesktopTargets(propGroup);
                 }
             }
 

--- a/src/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -282,6 +282,12 @@ namespace MSBuild.Abstractions
         public static void AddUseWPF(ProjectPropertyGroupElement propGroup) => propGroup.AddProperty(DesktopFacts.UseWPFPropertyName, "true");
 
         /// <summary>
+        /// Adds the ImportWindowsDesktopTargets=true property to ensure builds targeting .NET Framework will succeed.
+        /// </summary>
+        /// <param name="propGroup"></param>
+        public static void AddImportWindowsDesktopTargets(ProjectPropertyGroupElement propGroup) => propGroup.AddProperty(DesktopFacts.ImportWindowsDesktopTargetsName, "true");
+
+        /// <summary>
         /// Finds the property group with the TFM specified, which is normally the top-level property group.
         /// </summary>
         public static ProjectPropertyGroupElement GetOrCreateTopLevelPropertyGroupWithTFM(IProjectRootElement rootElement) =>

--- a/src/MSBuild.Conversion.Facts/DesktopFacts.cs
+++ b/src/MSBuild.Conversion.Facts/DesktopFacts.cs
@@ -54,6 +54,7 @@ namespace MSBuild.Conversion.Facts
         public const string WinSDKAttribute = "Microsoft.NET.Sdk.WindowsDesktop";
         public const string UseWPFPropertyName = "UseWPF";
         public const string UseWinFormsPropertyName = "UseWindowsForms";
+        public const string ImportWindowsDesktopTargetsName = "ImportWindowsDesktopTargets";
         public const string DesignerSuffix = ".Designer.cs";
         public const string XamlFileExtension = ".xaml";
         public const string SettingsDesignerFileName = "Settings.Designer.cs";

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -409,6 +409,13 @@ namespace MSBuild.Conversion.Project
                 MSBuildHelpers.AddUseWPF(propGroup);
             }
 
+            if (!baselineProject.GlobalProperties.Contains(DesktopFacts.ImportWindowsDesktopTargetsName, StringComparer.OrdinalIgnoreCase)
+             && !projectRootElement.Sdk.Equals(DesktopFacts.WinSDKAttribute)
+             && (MSBuildHelpers.IsWPF(projectRootElement) || MSBuildHelpers.IsWinForms(projectRootElement)))
+            {
+                MSBuildHelpers.AddImportWindowsDesktopTargets(propGroup);
+            }
+
             return projectRootElement;
         }
 

--- a/tests/TestData/SmokeTests.WinformsNet5Baseline/SmokeTests.WinformsNet5Baseline.csproj
+++ b/tests/TestData/SmokeTests.WinformsNet5Baseline/SmokeTests.WinformsNet5Baseline.csproj
@@ -5,6 +5,7 @@
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TestData/SmokeTests.WpfNet5Baseline/SmokeTests.WpfNet5Baseline.csproj
+++ b/tests/TestData/SmokeTests.WpfNet5Baseline/SmokeTests.WpfNet5Baseline.csproj
@@ -5,6 +5,7 @@
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is needed with .NET framework projects when using the new csproj
format to allow building WPF and WinForms.

See https://github.com/dotnet/sdk/issues/14716 for the discussion at the SDK on bringing support back without needing this flag.