### PR TITLE
Allow conversion of projects with unrecognized imports

### DIFF
--- a/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
+++ b/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
@@ -276,55 +276,21 @@ namespace MSBuild.Abstractions
                 return ProjectStyle.Custom;
             }
 
-            var cleansedImports = imports.Select(import => Path.GetFileName(import.Project));
-            var allImportsConvertibleToSdk =
-                cleansedImports.All(import =>
-                    MSBuildFacts.PropsConvertibleToSDK.Contains(import, StringComparer.OrdinalIgnoreCase) ||
-                    MSBuildFacts.TargetsConvertibleToSDK.Contains(import, StringComparer.OrdinalIgnoreCase));
-
-            if (allImportsConvertibleToSdk)
+            if (MSBuildHelpers.IsNETFrameworkMSTestProject(projectRootElement))
             {
-                if (MSBuildHelpers.IsNETFrameworkMSTestProject(projectRootElement))
-                {
-                    return ProjectStyle.MSTest;
-                }
-                else if (MSBuildHelpers.IsWPF(projectRootElement) || MSBuildHelpers.IsWinForms(projectRootElement) || MSBuildHelpers.IsDesktop(projectRootElement))
-                {
-                    return ProjectStyle.WindowsDesktop;
-                }
-                else if (MSBuildHelpers.IsWeb(projectRootElement))
-                {
-                    return ProjectStyle.Web;
-                }
-                else
-                {
-                    return ProjectStyle.Default;
-                }
+                return ProjectStyle.MSTest;
+            }
+            else if (MSBuildHelpers.IsWPF(projectRootElement) || MSBuildHelpers.IsWinForms(projectRootElement) || MSBuildHelpers.IsDesktop(projectRootElement))
+            {
+                return ProjectStyle.WindowsDesktop;
+            }
+            else if (MSBuildHelpers.IsWeb(projectRootElement))
+            {
+                return ProjectStyle.Web;
             }
             else
             {
-                Console.WriteLine("This project has custom imports that are not accepted by try-convert.");
-                Console.WriteLine("Unexpected custom imports were found:");
-
-                var customImports =
-                    cleansedImports.Where(import =>
-                        !(MSBuildFacts.PropsConvertibleToSDK.Contains(import, StringComparer.OrdinalIgnoreCase) ||
-                            MSBuildFacts.TargetsConvertibleToSDK.Contains(import, StringComparer.OrdinalIgnoreCase)));
-
-                foreach (var import in customImports)
-                {
-                    Console.WriteLine($"\t{import}");
-                }
-
-                Console.WriteLine("The following imports are considered valid for conversion:");
-
-                foreach (var import in MSBuildFacts.TargetsConvertibleToSDK.Union(MSBuildFacts.PropsConvertibleToSDK))
-                {
-                    Console.WriteLine($"\t{import}");
-                }
-
-                // It's something else, no idea what though
-                return ProjectStyle.Custom;
+                return ProjectStyle.Default;
             }
         }
 

--- a/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -10,15 +10,16 @@ namespace MSBuild.Conversion.Facts
     public static class MSBuildFacts
     {
         /// <summary>
-        /// Props files which are known to be imported in standard projects created from templates that can be converted to use the SDK
+        /// Props files which are known to be imported in standard projects created from templates that can be omitted from SDK projects.
         /// </summary>
         public static ImmutableArray<string> PropsConvertibleToSDK => ImmutableArray.Create(
             "Microsoft.Common.props",
-            "MSTest.TestAdapter.props"
+            "MSTest.TestAdapter.props",
+            "Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props"
         );
 
         /// <summary>
-        /// Targets files which are known to be imported in standard projects created from templates that can be converted to use the SDK.
+        /// Targets files which are known to be imported in standard projects created from templates that can be omitted from SDK projects.
         /// </summary>
         public static ImmutableArray<string> TargetsConvertibleToSDK => ImmutableArray.Create(
             "Microsoft.CSharp.targets",

--- a/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -12,16 +12,17 @@ namespace MSBuild.Conversion.Facts
         /// <summary>
         /// Props files which are known to be imported in standard projects created from templates that can be omitted from SDK projects.
         /// </summary>
-        public static ImmutableArray<string> PropsConvertibleToSDK => ImmutableArray.Create(
+        public static ImmutableArray<string> PropsToRemove => ImmutableArray.Create(
             "Microsoft.Common.props",
             "MSTest.TestAdapter.props",
-            "Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props"
+            "Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props",
+            "Microsoft.Net.Compilers.props" // https://stackoverflow.com/a/60623906
         );
 
         /// <summary>
         /// Targets files which are known to be imported in standard projects created from templates that can be omitted from SDK projects.
         /// </summary>
-        public static ImmutableArray<string> TargetsConvertibleToSDK => ImmutableArray.Create(
+        public static ImmutableArray<string> TargetsToRemove => ImmutableArray.Create(
             "Microsoft.CSharp.targets",
             "Microsoft.VisualBasic.targets",
             "Microsoft.Portable.CSharp.targets",
@@ -30,6 +31,14 @@ namespace MSBuild.Conversion.Facts
             "MSTest.TestAdapter.targets",
             "Microsoft.TestTools.targets",
             "Microsoft.WebApplication.targets"
+        );
+
+        /// <summary>
+        /// Props and targets files which are recognized and can be left unchanged during conversion.
+        /// </summary>
+        public static ImmutableArray<string> ImportsToKeep => ImmutableArray.Create(
+            "Microsoft.TypeScript.Default.props",
+            "Microsoft.TypeScript.targets"
         );
 
         /// <summary>

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -17,12 +17,12 @@ namespace MSBuild.Conversion.Project
             foreach (var import in projectRootElement.Imports)
             {
                 var fileName = Path.GetFileName(import.Project);
-                if (MSBuildFacts.PropsConvertibleToSDK.Contains(fileName, StringComparer.OrdinalIgnoreCase) ||
-                    MSBuildFacts.TargetsConvertibleToSDK.Contains(fileName, StringComparer.OrdinalIgnoreCase))
+                if (MSBuildFacts.PropsToRemove.Contains(fileName, StringComparer.OrdinalIgnoreCase) ||
+                    MSBuildFacts.TargetsToRemove.Contains(fileName, StringComparer.OrdinalIgnoreCase))
                 {
                     projectRootElement.RemoveChild(import);
                 }
-                else
+                else if (!MSBuildFacts.ImportsToKeep.Contains(fileName, StringComparer.OrdinalIgnoreCase))
                 {
                     Console.WriteLine($"This project has an unrecognized custom import which may need reviewed after conversion: {fileName}");
                 }

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -16,7 +16,16 @@ namespace MSBuild.Conversion.Project
         {
             foreach (var import in projectRootElement.Imports)
             {
-                projectRootElement.RemoveChild(import);
+                var fileName = Path.GetFileName(import.Project);
+                if (MSBuildFacts.PropsConvertibleToSDK.Contains(fileName, StringComparer.OrdinalIgnoreCase) ||
+                    MSBuildFacts.TargetsConvertibleToSDK.Contains(fileName, StringComparer.OrdinalIgnoreCase))
+                {
+                    projectRootElement.RemoveChild(import);
+                }
+                else
+                {
+                    Console.WriteLine($"This project has an unrecognized custom import which may need reviewed after conversion: {fileName}");
+                }
             }
 
             if (baselineProject.ProjectStyle is ProjectStyle.WindowsDesktop && baselineProject.TargetTFM is MSBuildFacts.NetCoreApp31)


### PR DESCRIPTION
This updates try-convert's response to unrecognized imports. Rather than failing the conversion, the conversion proceeds and the unrecognized imports are left unchanged.

If the imported props or targets file is not one recognized as an allowable import, the user is given a message warning that the import may not work with the converted project file.

Fixes #370 