### PR TITLE
Don't use web SDK for libraries still targeting .NET Framework

### DIFF
--- a/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
+++ b/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
@@ -146,7 +146,7 @@ namespace MSBuild.Abstractions
                         // Web apps should use the web SDK (there's no good way to build a classic web apps with SDK-style projects)
                         // but libraries with web dependencies should only use the web SDK if the TFM is updating. Otherwise, they
                         // can work as classic ASP.NET libraries.
-                        MSBuildHelpers.IsWebApp(root) || !keepCurrentTFMs
+                        MSBuildHelpers.IsAspNetCore(root, keepCurrentTFMs ? project.GetTargetFramework() : tfm)
                             ? WebFacts.WebSDKAttribute
                             : MSBuildFacts.DefaultSDKAttribute;
                     break;

--- a/src/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -229,6 +229,21 @@ namespace MSBuild.Abstractions
         }
 
         /// <summary>
+        /// Determines if a given project uses ASP.NET web app project type guid
+        /// </summary>
+        public static bool IsWebApp(IProjectRootElement projectRoot) =>
+            projectRoot.PropertyGroups.Any(pg => pg.Properties.Any(ProjectPropertyHelpers.IsLegacyWebProjectTypeGuidsProperty));
+
+        /// <summary>
+        /// Determines if a project should be treated as an ASP.NET Core project (as opposed to classic ASP.NET). Returns
+        /// true if the project is a web app (since there's no good way to build an ASP.NET app with an SDK-style project
+        /// except to upgrade to ASP.NET Core) or the project has web dependencies and will target .NET/.NET Core.
+        /// </summary>
+        public static bool IsAspNetCore(IProjectRootElement projectRoot, string tfm) =>
+            IsWebApp(projectRoot) || projectRoot.Sdk.Equals(WebFacts.WebSDKAttribute)
+            || (IsWeb(projectRoot) && new[] { MSBuildFacts.Net5, MSBuildFacts.NetcoreappPrelude }.Any(s => tfm.StartsWith(s, StringComparison.OrdinalIgnoreCase)));
+
+        /// <summary>
         /// Determines if a project is a .NET Framework MSTest project by looking at its references.
         /// </summary>
         /// <param name="root"></param>

--- a/src/MSBuild.Abstractions/ProjectPropertyHelpers.cs
+++ b/src/MSBuild.Abstractions/ProjectPropertyHelpers.cs
@@ -97,7 +97,7 @@ namespace MSBuild.Abstractions
         /// Determines if a property lists the default project type GUIds for legacy web projects.
         /// </summary>
         public static bool IsLegacyWebProjectTypeGuidsProperty(ProjectPropertyElement prop) =>
-            IsProjectTypeGuidsNode(prop) && prop.Value.Split(';').Any(guidString => MSBuildFacts.LegacyWebProjectTypeGuids.Contains(Guid.Parse(guidString)));
+            IsProjectTypeGuidsNode(prop) && prop.Value.Split(';').Any(guidString => WebFacts.LegacyWebProjectTypeGuids.Contains(Guid.Parse(guidString)));
 
         /// <summary>
         /// Checks if a given OutputType node is wither a library, exe, or WinExe.

--- a/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -146,9 +146,11 @@ namespace MSBuild.Conversion.Facts
             "System.EnterpriseServices",
 
             // System.Net.Http is a part of the .NET SDK now
-            "System.Net.Http",
+            "System.Net.Http"
+        );
 
-            // ASP.NET references are no longer used
+        public static ImmutableArray<string> UnnecessaryWebIncludes => ImmutableArray.Create(
+            // ASP.NET references are no longer used by web apps
             "System.Web",
             "System.Web.Abstractions",
             "System.Web.ApplicationServices",
@@ -242,15 +244,6 @@ namespace MSBuild.Conversion.Facts
 
         public static ImmutableArray<string> ItemsThatCanHaveMetadataRemoved => ImmutableArray.Create(
             "ProjectReference"
-        );
-
-        public static ImmutableArray<Guid> LegacyWebProjectTypeGuids => ImmutableArray.Create(
-            Guid.Parse("{349c5851-65df-11da-9384-00065b846f21}"), // ASP.NET MVC 5
-            Guid.Parse("{E3E379DF-F4C6-4180-9B81-6769533ABE47}"), // ASP.NET MVC 4
-            Guid.Parse("{E53F8FEA-EAE0-44A6-8774-FFD645390401}"), // ASP.NET MVC 3
-            Guid.Parse("{F85E285D-A4E0-4152-9332-AB1D724D3325}"), // ASP.NET MVC 2
-            Guid.Parse("{603C0E0B-DB56-11DC-BE95-000D561079B0}"), // ASP.NET MVC 1
-            Guid.Parse("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") // ASP.NET 5
         );
 
         public static ImmutableArray<Guid> LanguageProjectTypeGuids => ImmutableArray.Create(

--- a/src/MSBuild.Conversion.Facts/WebFacts.cs
+++ b/src/MSBuild.Conversion.Facts/WebFacts.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 
 namespace MSBuild.Conversion.Facts
 {
@@ -8,6 +9,15 @@ namespace MSBuild.Conversion.Facts
         public const string MvcBuildViewsName = "MvcBuildViews";
         public const string WebProjectPropertiesName = "WebProjectProperties";
         public const string WebApplicationTargets = "Microsoft.WebApplication.targets";
+
+        public static ImmutableArray<Guid> LegacyWebProjectTypeGuids => ImmutableArray.Create(
+            Guid.Parse("{349c5851-65df-11da-9384-00065b846f21}"), // ASP.NET MVC 5
+            Guid.Parse("{E3E379DF-F4C6-4180-9B81-6769533ABE47}"), // ASP.NET MVC 4
+            Guid.Parse("{E53F8FEA-EAE0-44A6-8774-FFD645390401}"), // ASP.NET MVC 3
+            Guid.Parse("{F85E285D-A4E0-4152-9332-AB1D724D3325}"), // ASP.NET MVC 2
+            Guid.Parse("{603C0E0B-DB56-11DC-BE95-000D561079B0}"), // ASP.NET MVC 1
+            Guid.Parse("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") // ASP.NET 5
+        );
 
         /// <summary>
         /// The core set of references all ASP.NET projects use.

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -32,8 +32,10 @@ namespace MSBuild.Conversion.Project
             {
                 projectRootElement.Sdk = DesktopFacts.WinSDKAttribute;
             }
-            else if (MSBuildHelpers.IsWeb(projectRootElement))
+            else if (MSBuildHelpers.IsAspNetCore(projectRootElement, baselineProject.TargetTFM))
             {
+                // Libraries targeting .NET Framework can use the default SDK and still be used by NetFx callers.
+                // However, web apps (as opposed to libraries) or libraries that are targeting .NET Core/.NET should use the web SDK.
                 projectRootElement.Sdk = WebFacts.WebSDKAttribute;
             }
             else
@@ -171,6 +173,10 @@ namespace MSBuild.Conversion.Project
                     }
 
                     if (MSBuildFacts.UnnecessaryItemIncludes.Contains(item.Include, StringComparer.OrdinalIgnoreCase))
+                    {
+                        itemGroup.RemoveChild(item);
+                    }
+                    else if (MSBuildFacts.UnnecessaryWebIncludes.Contains(item.Include, StringComparer.OrdinalIgnoreCase) && MSBuildHelpers.IsAspNetCore(projectRootElement, tfm))
                     {
                         itemGroup.RemoveChild(item);
                     }
@@ -361,6 +367,12 @@ namespace MSBuild.Conversion.Project
                     }
 
                     if (MSBuildFacts.UnnecessaryItemIncludes.Contains(pkgref.ID, StringComparer.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (MSBuildFacts.UnnecessaryWebIncludes.Contains(pkgref.ID, StringComparer.OrdinalIgnoreCase)
+                        && MSBuildHelpers.IsAspNetCore(projectRootElement, tfm))
                     {
                         continue;
                     }

--- a/tests/TestData/SmokeTests.LegacyWebLibrary/Properties/AssemblyInfo.cs
+++ b/tests/TestData/SmokeTests.LegacyWebLibrary/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Helper")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Helper")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9be957f4-d033-4dd4-83cc-77fb64ab3020")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/TestData/SmokeTests.LegacyWebLibrary/SmokeTests.LegacyWebLibrary.csproj
+++ b/tests/TestData/SmokeTests.LegacyWebLibrary/SmokeTests.LegacyWebLibrary.csproj
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9BE957F4-D033-4DD4-83CC-77FB64AB3020}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SmokeTests.LegacyWebLibrary</RootNamespace>
+    <AssemblyName>SmokeTests.LegacyWebLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WebHelpers.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/TestData/SmokeTests.LegacyWebLibrary/WebHelpers.cs
+++ b/tests/TestData/SmokeTests.LegacyWebLibrary/WebHelpers.cs
@@ -1,0 +1,11 @@
+﻿using System.Web;
+using System.Web.Mvc;
+
+namespace Helper
+{
+    public static class WebHelpers
+    {
+        public static string GetClientAddress() =>
+            Newtonsoft.Json.JsonConvert.SerializeObject(new { Verb = HttpVerbs.Get, Address = HttpContext.Current.Request.UserHostAddress });
+    }
+}

--- a/tests/TestData/SmokeTests.LegacyWebLibrary/packages.config
+++ b/tests/TestData/SmokeTests.LegacyWebLibrary/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net472" />
+</packages>

--- a/tests/TestData/SmokeTests.WebLibraryNet5Baseline/Properties/AssemblyInfo.cs
+++ b/tests/TestData/SmokeTests.WebLibraryNet5Baseline/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Helper")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Helper")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9be957f4-d033-4dd4-83cc-77fb64ab3020")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/TestData/SmokeTests.WebLibraryNet5Baseline/SmokeTests.WebLibraryNet5Baseline.csproj
+++ b/tests/TestData/SmokeTests.WebLibraryNet5Baseline/SmokeTests.WebLibraryNet5Baseline.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.5" />
+  </ItemGroup>
+</Project>

--- a/tests/TestData/SmokeTests.WebLibraryNet5Baseline/WebHelpers.cs
+++ b/tests/TestData/SmokeTests.WebLibraryNet5Baseline/WebHelpers.cs
@@ -1,0 +1,11 @@
+﻿using System.Web;
+using System.Web.Mvc;
+
+namespace Helper
+{
+    public static class WebHelpers
+    {
+        public static string GetClientAddress() =>
+            Newtonsoft.Json.JsonConvert.SerializeObject(new { Verb = HttpVerbs.Get, Address = HttpContext.Current.Request.UserHostAddress });
+    }
+}

--- a/tests/TestData/SmokeTests.WebLibraryNetFxBaseline/Properties/AssemblyInfo.cs
+++ b/tests/TestData/SmokeTests.WebLibraryNetFxBaseline/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Helper")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Helper")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9be957f4-d033-4dd4-83cc-77fb64ab3020")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/TestData/SmokeTests.WebLibraryNetFxBaseline/SmokeTests.WebLibraryNetFxBaseline.csproj
+++ b/tests/TestData/SmokeTests.WebLibraryNetFxBaseline/SmokeTests.WebLibraryNetFxBaseline.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.7" />
+    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.5" />
+  </ItemGroup>
+</Project>

--- a/tests/TestData/SmokeTests.WebLibraryNetFxBaseline/WebHelpers.cs
+++ b/tests/TestData/SmokeTests.WebLibraryNetFxBaseline/WebHelpers.cs
@@ -1,0 +1,11 @@
+﻿using System.Web;
+using System.Web.Mvc;
+
+namespace Helper
+{
+    public static class WebHelpers
+    {
+        public static string GetClientAddress() =>
+            Newtonsoft.Json.JsonConvert.SerializeObject(new { Verb = HttpVerbs.Get, Address = HttpContext.Current.Request.UserHostAddress });
+    }
+}

--- a/tests/end-to-end/Smoke.Tests/BasicConversions.cs
+++ b/tests/end-to-end/Smoke.Tests/BasicConversions.cs
@@ -82,17 +82,33 @@ namespace SmokeTests
             AssertConversionWorks(projectToConvertPath, projectBaselinePath, "netcoreapp3.1");
         }
 
-        private void AssertConversionWorks(string projectToConvertPath, string projectBaselinePath, string targetTFM)
+        [Fact]
+        public void ConvertsLegacyWebLibraryToNetFx()
         {
-            var (baselineRootElement, convertedRootElement) = GetRootElementsForComparison(projectToConvertPath, projectBaselinePath, targetTFM);
+            var projectToConvertPath = GetCSharpProjectPath("SmokeTests.LegacyWebLibrary");
+            var projectBaselinePath = GetCSharpProjectPath("SmokeTests.WebLibraryNetFxBaseline");
+            AssertConversionWorks(projectToConvertPath, projectBaselinePath, "net472", true);
+        }
+
+        [Fact]
+        public void ConvertsLegacyWebLibraryToNet5()
+        {
+            var projectToConvertPath = GetCSharpProjectPath("SmokeTests.LegacyWebLibrary");
+            var projectBaselinePath = GetCSharpProjectPath("SmokeTests.WebLibraryNet5Baseline");
+            AssertConversionWorks(projectToConvertPath, projectBaselinePath, "net5.0", true);
+        }
+
+        private void AssertConversionWorks(string projectToConvertPath, string projectBaselinePath, string targetTFM, bool forceWeb = false)
+        {
+            var (baselineRootElement, convertedRootElement) = GetRootElementsForComparison(projectToConvertPath, projectBaselinePath, targetTFM, forceWeb);
             AssertPropsEqual(baselineRootElement, convertedRootElement);
             AssertItemsEqual(baselineRootElement, convertedRootElement);
         }
 
-        private static (IProjectRootElement baselineRootElement, IProjectRootElement convertedRootElement) GetRootElementsForComparison(string projectToConvertPath, string projectBaselinePath, string targetTFM)
+        private static (IProjectRootElement baselineRootElement, IProjectRootElement convertedRootElement) GetRootElementsForComparison(string projectToConvertPath, string projectBaselinePath, string targetTFM, bool forceWeb)
         {
             var conversionLoader = new MSBuildConversionWorkspaceLoader(projectToConvertPath, MSBuildConversionWorkspaceType.Project);
-            var conversionWorkspace = conversionLoader.LoadWorkspace(projectToConvertPath, noBackup: true, targetTFM, false, forceWeb: false);
+            var conversionWorkspace = conversionLoader.LoadWorkspace(projectToConvertPath, noBackup: true, targetTFM, false, forceWeb);
 
             var baselineLoader = new MSBuildConversionWorkspaceLoader(projectBaselinePath, MSBuildConversionWorkspaceType.Project);
             var baselineRootElement = baselineLoader.GetRootElementFromProjectFile(projectBaselinePath);


### PR DESCRIPTION
This updates how try-convert detects and handles web projects so that libraries which have System.Web dependencies will be treated as default class libraries if they're not updating to a .NET Core/.NET 5 TFM.

This enables libraries (with System.Web) dependencies to use try-convert to update to SDK style while still keeping web dependencies that they need to function.

Web apps (as opposed to libraries) and any projects with web dependencies which are moving off of NetFx are still updated to use the web SDK as these scenarios don't work with classic ASP.NET dependencies.