### PR TITLE
Update `AddDesktopProperties` to add desktop props for all project styles

### DIFF
--- a/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
+++ b/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
@@ -167,28 +167,25 @@ namespace MSBuild.Abstractions
             };
             propGroup.AddProperty(MSBuildFacts.OutputTypeNodeName, outputTypeValue ?? throw new InvalidOperationException($"OutputType is not set! '{projectFilePath}'"));
 
-            if (projectStyle == ProjectStyle.WindowsDesktop)
+            if (MSBuildHelpers.IsWinForms(root))
             {
-                if (MSBuildHelpers.IsWinForms(root))
-                {
-                    MSBuildHelpers.AddUseWinForms(propGroup);
-                }
+                MSBuildHelpers.AddUseWinForms(propGroup);
+            }
 
-                if (MSBuildHelpers.IsWPF(root))
-                {
-                    MSBuildHelpers.AddUseWPF(propGroup);
-                }
+            if (MSBuildHelpers.IsWPF(root))
+            {
+                MSBuildHelpers.AddUseWPF(propGroup);
+            }
 
-                // User is referencing WindowsBase only
-                if (MSBuildHelpers.IsDesktop(root) && !MSBuildHelpers.HasWPFOrWinForms(propGroup))
-                {
-                    MSBuildHelpers.AddUseWinForms(propGroup);
-                }
+            // User is referencing WindowsBase only
+            if (MSBuildHelpers.IsDesktop(root) && !MSBuildHelpers.HasWPFOrWinForms(propGroup))
+            {
+                MSBuildHelpers.AddUseWinForms(propGroup);
+            }
 
-                if (MSBuildHelpers.HasWPFOrWinForms(propGroup) && tfm.ContainsIgnoreCase(MSBuildFacts.Net5))
-                {
-                    MSBuildHelpers.AddImportWindowsDesktopTargets(propGroup);
-                }
+            if (MSBuildHelpers.HasWPFOrWinForms(propGroup) && tfm.ContainsIgnoreCase(MSBuildFacts.Net5))
+            {
+                MSBuildHelpers.AddImportWindowsDesktopTargets(propGroup);
             }
 
             // Create a new collection because a project with this name has already been loaded into the global collection.

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -410,11 +410,6 @@ namespace MSBuild.Conversion.Project
 
         public static IProjectRootElement AddDesktopProperties(this IProjectRootElement projectRootElement, BaselineProject baselineProject)
         {
-            if (baselineProject.ProjectStyle != ProjectStyle.WindowsDesktop)
-            {
-                return projectRootElement;
-            }
-
             // Don't create a new prop group; put the desktop properties in the same group as where TFM is located
             var propGroup = MSBuildHelpers.GetOrCreateTopLevelPropertyGroupWithTFM(projectRootElement);
 


### PR DESCRIPTION
A customer ran into an issue where an MSTest project with references to PresentationFramework and PresentationCore wasn't getting a `UseWPF` property during conversion. 

This PR updates `AddDesktopProperties` to allow adding desktop properties for any project styles (not just Windows desktop ones) since other project types (MSTest, for example) could have WPF or WinForms dependencies and benefit from the desktop properties.

I've tried to think through if there's any reason we *wouldn't* want these properties in projects that didn't evaluate to WindowsDesktop project style (which I think will only be MSTest or Custom projects since [those are the ones that are checked before desktop currently](https://github.com/dotnet/try-convert/blob/main/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs#L294)) and I can't think of anything. Let me know if you can think of any cases where we wouldn't want these added.