### PR TITLE
Add support for legacy MSTest using nuget packages

### DIFF
--- a/src/MSBuild.Abstractions/MSBuildHelpers.cs
+++ b/src/MSBuild.Abstractions/MSBuildHelpers.cs
@@ -249,14 +249,20 @@ namespace MSBuild.Abstractions
         /// <returns></returns>
         public static bool IsNETFrameworkMSTestProject(IProjectRootElement projectRoot)
         {
+            var packages = GetOrCreatePackageReferencesItemGroup(projectRoot).Items.Select(elem => elem.Include);
             var references = projectRoot.ItemGroups.SelectMany(GetReferences)?.Select(elem => elem.Include.Split(',').First());
-            if (references is null)
+            if (references is null && packages is null)
             {
                 return false;
             }
             else
             {
-                return MSTestFacts.MSTestReferences.All(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
+                var hasTestReference = false;
+                if(references != null)
+                    hasTestReference = MSTestFacts.MSTestReferences.All(reference => references.Contains(reference, StringComparer.OrdinalIgnoreCase));
+                if (references != null)
+                    hasTestReference = hasTestReference || MSTestFacts.MSTestPackages.All(package => packages.Contains(package, StringComparer.OrdinalIgnoreCase));
+                return hasTestReference;
             }
         }
 

--- a/src/MSBuild.Conversion.Facts/MSTestFacts.cs
+++ b/src/MSBuild.Conversion.Facts/MSTestFacts.cs
@@ -25,6 +25,11 @@ namespace MSBuild.Conversion.Facts
             "Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions"
         );
 
+        public static ImmutableArray<string> MSTestPackages = ImmutableArray.Create(
+            "MSTest.TestAdapter",
+            "MSTest.TestFramework"
+        );
+
         public const string IsCodedUITestNodeName = "IsCodedUITest";
         public const string TestProjectTypeNodeName = "TestProjectType";
         public const string UnitTestTestProjectType = "UnitTest";


### PR DESCRIPTION
This will fix issue https://github.com/dotnet/try-convert/issues/421.  Not e project does not convert to dotnet 6 properly needs https://github.com/dotnet/try-convert/pull/436