### PR TITLE
Hurlburb/newtonsoft 13 0 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ build.cmd
 To use the tool locally, you need to build it from source. Once it's built, the tool will live under:
 
 ```
-/artifacts/bin/try-convert/Debug/net5.0/try-convert.exe
+/artifacts/bin/try-convert/Debug/net6.0/try-convert.exe
 ```
 
 Alternatively, you can look at the following directory and copy that into somewhere else on your machine:
 
 ```
-mv /artifacts/bin/try-convert/Debug/net5.0/publish C:/Users/<user>/try-convert
+mv /artifacts/bin/try-convert/Debug/net6.0/publish C:/Users/<user>/try-convert
 ```
 
 You can invoke the tool from the publish directory as well.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildVersion>16.7</MicrosoftBuildVersion>
     <MicrosoftWin32RegistryVersion>5.0.0-rc.1.20451.14</MicrosoftWin32RegistryVersion>
-    <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NuGetVersioningVersion>5.8.0-preview.3.6823</NuGetVersioningVersion>
     <SystemCollectionsImmutableVersion>5.0.0-rc.1.20451.14</SystemCollectionsImmutableVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20371.2</SystemCommandLineVersion>


### PR DESCRIPTION
Newtonsoft.JSON needs updating due to a security vulnerability.

Additionally, try-convert now builds for net6.0, so docs needed a minor update