### PR TITLE
Convert winmdobj project type to CsWinRT component projects

### DIFF
--- a/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
+++ b/src/MSBuild.Abstractions/MSBuildConversionWorkspace.cs
@@ -237,6 +237,7 @@ namespace MSBuild.Abstractions
                 ProjectOutputType.Library => true,
                 ProjectOutputType.WinExe => true,
                 ProjectOutputType.AppContainerExe => true,
+                ProjectOutputType.WinMdObj => true,
                 _ => false
             };
 
@@ -282,6 +283,10 @@ namespace MSBuild.Abstractions
             else if (ProjectPropertyHelpers.IsAppContainerExeOutputType(outputTypeNode))
             {
                 return ProjectOutputType.AppContainerExe;
+            }
+            else if (ProjectPropertyHelpers.IsWinMdObjProjectType(outputTypeNode))
+            {
+                return ProjectOutputType.WinMdObj;
             }
             else
             {

--- a/src/MSBuild.Abstractions/ProjectOutputType.cs
+++ b/src/MSBuild.Abstractions/ProjectOutputType.cs
@@ -13,6 +13,7 @@ namespace MSBuild.Abstractions
         Exe,
         WinExe,
         AppContainerExe,
+        WinMdObj,
         Other,
         None
     }

--- a/src/MSBuild.Abstractions/ProjectPropertyHelpers.cs
+++ b/src/MSBuild.Abstractions/ProjectPropertyHelpers.cs
@@ -170,6 +170,13 @@ namespace MSBuild.Abstractions
             prop.ElementName.Equals(MSBuildFacts.OutputTypeNodeName, StringComparison.OrdinalIgnoreCase)
             && prop.Value.Equals(MSBuildFacts.WinExeOutputType, StringComparison.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Checks if an OutputType node is Exe.
+        /// </summary>
+        public static bool IsWinMdObjProjectType(ProjectPropertyElement prop) =>
+            prop.ElementName.Equals(MSBuildFacts.OutputTypeNodeName, StringComparison.OrdinalIgnoreCase)
+            && prop.Value.Equals(MSBuildFacts.WinMdObjOutputType, StringComparison.OrdinalIgnoreCase);
+
         public static bool IsVisualBasicProject(ProjectPropertyElement prop) =>
             IsProjectTypeGuidsNode(prop) && prop.Value.Split(';').Any(guidString => Guid.Parse(guidString) == MSBuildFacts.LanguageProjectTypeVisualBasic);
 

--- a/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
+++ b/src/MSBuild.Conversion.Facts/MSBuildFacts.cs
@@ -259,6 +259,8 @@ namespace MSBuild.Conversion.Facts
             Guid.Parse("{F2A71F9B-5D33-465A-A702-920D77279786}") // F#
         );
 
+        public static readonly (string Name, string Version) CsWinRTPackageReference = (Name: "Microsoft.Windows.CsWinRT", Version: "1.6.4");
+
         public const string DefaultSDKAttribute = "Microsoft.NET.Sdk";
         public const string LowestFrameworkVersionWithSystemValueTuple = "net47";
         public const string SharedProjectsImportLabel = "Shared";
@@ -290,6 +292,7 @@ namespace MSBuild.Conversion.Facts
         public const string ExeOutputType = "Exe";
         public const string WinExeOutputType = "WinExe";
         public const string AppContainerExeOutputType = "AppContainerExe";
+        public const string WinMdObjOutputType = "winmdobj";
         public const string NuGetPackageImportStampNodeName = "NuGetPackageImportStamp";
         public const string ReferencePathNodeName = "ReferencePath";
         public const string LegacyTargetFrameworkPropertyNodeName = "TargetFrameworkIdentifier";
@@ -313,5 +316,6 @@ namespace MSBuild.Conversion.Facts
         public const string TargetPlatformIdentifierNodeName = "TargetPlatformIdentifier";
         public const string UapValue = "UAP";
         public const string TargetPlatformVersionNodeName = "TargetPlatformVersion";
+        public const string CsWinRTComponentName = "CsWinRTComponent";
     }
 }

--- a/src/MSBuild.Conversion.Project/Converter.cs
+++ b/src/MSBuild.Conversion.Project/Converter.cs
@@ -42,6 +42,7 @@ namespace MSBuild.Conversion.Project
 
                 // Now we can convert the project over
                 .ChangeImportsAndAddSdkAttribute(_sdkBaselineProject, _forceRemoveCustomImports)
+                .AddCsWinRTReferenceAndComponentProperty(_sdkBaselineProject)
                 .UpdateOutputTypeProperty(_sdkBaselineProject)
                 .RemoveDefaultedProperties(_sdkBaselineProject, _differs)
                 .RemoveUnnecessaryPropertiesNotInSDKByDefault(_sdkBaselineProject.ProjectStyle)

--- a/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
+++ b/src/MSBuild.Conversion.Project/ProjectRootElementExtensionsForConversion.cs
@@ -65,6 +65,21 @@ namespace MSBuild.Conversion.Project
             return projectRootElement;
         }
 
+        public static IProjectRootElement AddCsWinRTReferenceAndComponentProperty(this IProjectRootElement projectRootElement, BaselineProject baselineProject)
+        {
+            if (baselineProject.OutputType == ProjectOutputType.WinMdObj)
+            {
+                var topLevelPropGroup = MSBuildHelpers.GetOrCreateTopLevelPropertyGroup(baselineProject, projectRootElement);
+                topLevelPropGroup.AddProperty(MSBuildFacts.CsWinRTComponentName, "true");
+
+                var itemGroup = projectRootElement.ItemGroups.Where(ig => ig.Items.Where(i => i.ItemType == MSBuildFacts.MSBuildPackageReferenceName).Any())
+                    .FirstOrDefault() ?? projectRootElement.AddItemGroup();
+                AddPackageReferenceElement(itemGroup, MSBuildFacts.CsWinRTPackageReference.Name, MSBuildFacts.CsWinRTPackageReference.Version);
+            }
+
+            return projectRootElement;
+        }
+
         public static IProjectRootElement UpdateOutputTypeProperty(this IProjectRootElement projectRootElement, BaselineProject baselineProject)
         {
             var outputTypeNode = projectRootElement.GetOutputTypeNode();
@@ -76,6 +91,7 @@ namespace MSBuild.Conversion.Project
                     ProjectOutputType.Library => MSBuildFacts.LibraryOutputType,
                     ProjectOutputType.WinExe => MSBuildFacts.WinExeOutputType,
                     ProjectOutputType.AppContainerExe => MSBuildFacts.WinExeOutputType,
+                    ProjectOutputType.WinMdObj => MSBuildFacts.LibraryOutputType,
                     _ => throw new InvalidOperationException("Unsupported output type: " + baselineProject.OutputType)
                 };
             }


### PR DESCRIPTION
Winmdobj is a .net native style of project OutputType which requires built in knowledge of .net native to generate winmd files.
The PR outputs winmdobj project as simple Library projects with .NET 6 and uses CsWinRT for authoring the winmd files.